### PR TITLE
Update typing.py: Add get_if_exists to ActorRemoteOptions

### DIFF
--- a/sunray/_internal/typing.py
+++ b/sunray/_internal/typing.py
@@ -43,6 +43,7 @@ class ActorRemoteOptions(TypedDict, total=False):
     runtime_env: RuntimeEnv | dict[str, Any]
     concurrency_groups: dict[str, int]
     scheduling_strategy: SchedulingStrategy
+    get_if_exists: bool
 
 
 class FunctionRemoteOptions(TypedDict, total=False):


### PR DESCRIPTION
`get_if_exists` has become a valid ray actor option. Please accept it in sunray too :)